### PR TITLE
fix: number-spinner concatenates value instead of incrementing number

### DIFF
--- a/src/components/number-spinner/index.js
+++ b/src/components/number-spinner/index.js
@@ -20,7 +20,7 @@ module.exports = require('marko-widgets').defineComponent({
         // in the state and that will be the current
         // integer value of the number spinner
         return {
-            value: value
+            value: parseInt(value)
         };
     },
     getTemplateData: function(state, input) {


### PR DESCRIPTION
when initialized via:

```
<number-spinner value="4" />
```

results in `41` when you press '+' button
